### PR TITLE
changed bypass behavior

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -57,8 +57,8 @@ class reactor:
         return {
             "required": {
                 "enabled": ("BOOLEAN", {"default": True, "label_off": "OFF", "label_on": "ON"}),
-                "source_image": ("IMAGE",),
                 "input_image": ("IMAGE",),               
+                "source_image": ("IMAGE",),
                 "swap_model": (list(model_names().keys()),),
                 "facedetection": (["retinaface_resnet50", "retinaface_mobile0.25", "YOLOv5l", "YOLOv5n"],),
                 "face_restore_model": (restorer_names(),),


### PR DESCRIPTION
changed node so when it is marked as bypass,
it will pass through the input_image
rather than the face source_image

it looks like comfyui just uses the first input that matches the output when bypassed, so swapping the order changes the bypass output behavior
fixes Gourieff/comfyui-reactor-node#51