### PR TITLE
FIX: do not clean up protobuf module.

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -32,7 +32,7 @@ sys.path.remove(repo_dir)
 # Remove any new modules
 modules_to_remove = []
 for module in sys.modules:
-    if module not in original_modules:
+    if module not in original_modules and not module.startswith("google.protobuf"):
         modules_to_remove.append(module)
 for module in modules_to_remove:
     del sys.modules[module]


### PR DESCRIPTION
There is an issue with protobuf - it does not like to be re-imported after being imported and deleted, specifically  https://github.com/protocolbuffers/protobuf/issues/3276#issuecomment-444008751 very closely describes the behavior of reactor's `__init__.py` where it cleans up imported modules. If there is another custom node that wants to use protobuf, it will fail to load with the stack trace below. The minimal reproducible example is to create the following "custom node" and try to load ComfyUI:

```
import google.protobuf.descriptor_pb2

NODE_CLASS_MAPPINGS={}
NODE_DISPLAY_NAME_MAPPINGS={}

__all__ = ["NODE_CLASS_MAPPINGS", "NODE_DISPLAY_NAME_MAPPINGS"]
```

Here is the stack trace:

```
Traceback (most recent call last):
  File "/home/akvochko/ComfyUI/nodes.py", line 1800, in load_custom_node
    module_spec.loader.exec_module(module)
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/home/akvochko/ComfyUI/custom_nodes/my_module.py", line 1, in <module>
    import google.protobuf.descriptor_pb2
  File "/home/akvochko/ComfyUI/.venv/lib/python3.10/site-packages/google/protobuf/descriptor_pb2.py", line 1855, in <module>
    _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'google.protobuf.descriptor_pb2', globals())
  File "/home/akvochko/ComfyUI/.venv/lib/python3.10/site-packages/google/protobuf/internal/builder.py", line 108, in BuildTopDescriptorsAndMessages
    module[name] = BuildMessage(msg_des)
  File "/home/akvochko/ComfyUI/.venv/lib/python3.10/site-packages/google/protobuf/internal/builder.py", line 85, in BuildMessage
    message_class = _reflection.GeneratedProtocolMessageType(
TypeError: A Message class can only inherit from Message

Cannot import /home/akvochko/ComfyUI/custom_nodes/my_module.py module for custom nodes: A Message class can only inherit from Message

Import times for custom nodes:
   0.0 seconds (IMPORT FAILED): /home/akvochko/ComfyUI/custom_nodes/my_module.py
   1.0 seconds: /home/akvochko/ComfyUI/custom_nodes/comfyui-reactor-node

Starting server

To see the GUI go to: http://127.0.0.1:8188
```

This PR fixes the issue by excluding all protobuf modules from the `modules_to_remove` list.