### PR TITLE
fix: incorrect albucore version was not importing the custom nodes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+albucore==0.0.16
 insightface==0.7.3
 onnx>=1.14.0
 opencv-python>=4.7.0.72


### PR DESCRIPTION
I tested in my machine downgrading that dependency `pip install albucore==0.0.16`

This other project also had the same problem, and the final fix for everybody was setting the version in the requirements. (haven't tested in my local with the change in the requeriments.txt, just running the command directly).

https://github.com/ostris/ai-toolkit/issues/182