### PR TITLE
Unload models to free vram

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -32,6 +32,9 @@ from scripts.reactor_faceswap import (
     half_det_size,
     providers
 )
+from scripts.reactor_swapper import (
+    unload_all_models,
+)
 from scripts.reactor_logger import logger
 from reactor_utils import (
     batch_tensor_to_pil,
@@ -1177,6 +1180,23 @@ class ReActorFaceBoost:
         }
         return (face_boost, )
     
+class ReActorUnload:
+    @classmethod
+    def INPUT_TYPES(s):
+        return {
+            "required": {
+                "trigger": ("IMAGE", ),
+            },
+        }
+
+    RETURN_TYPES = ("IMAGE",)
+    FUNCTION = "execute"
+    CATEGORY = "🌌 ReActor"
+
+    def execute(self, trigger):
+        unload_all_models()
+        return (trigger,)
+
 
 NODE_CLASS_MAPPINGS = {
     # --- MAIN NODES ---
@@ -1194,6 +1214,7 @@ NODE_CLASS_MAPPINGS = {
     "ReActorRestoreFace": RestoreFace,
     "ReActorImageDublicator": ImageDublicator,
     "ImageRGBA2RGB": ImageRGBA2RGB,
+    "ReActorUnload": ReActorUnload,
 }
 
 NODE_DISPLAY_NAME_MAPPINGS = {
@@ -1212,4 +1233,5 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     "ReActorRestoreFace": "Restore Face 🌌 ReActor",
     "ReActorImageDublicator": "Image Dublicator (List) 🌌 ReActor",
     "ImageRGBA2RGB": "Convert RGBA to RGB 🌌 ReActor",
+    "ReActorUnload": "Unload ReActor Models 🌌 ReActor",
 }

--- a/scripts/reactor_swapper.py
+++ b/scripts/reactor_swapper.py
@@ -69,6 +69,21 @@ TARGET_IMAGE_HASH = None
 TARGET_FACES_LIST = []
 TARGET_IMAGE_LIST_HASH = []
 
+def unload_model(model):
+    if model is not None:
+        # check if model has unload method
+        # if "unload" in model:
+        #     model.unload()
+        # if "model_unload" in model:
+        #     model.model_unload()
+        del model
+    return None
+
+def unload_all_models():
+    global FS_MODEL, CURRENT_FS_MODEL_PATH
+    FS_MODEL = unload_model(FS_MODEL)
+    ANALYSIS_MODELS["320"] = unload_model(ANALYSIS_MODELS["320"])
+    ANALYSIS_MODELS["640"] = unload_model(ANALYSIS_MODELS["640"])
 
 def get_current_faces_model():
     global SOURCE_FACES
@@ -88,8 +103,9 @@ def getAnalysisModel(det_size = (640, 640)):
 def getFaceSwapModel(model_path: str):
     global FS_MODEL
     global CURRENT_FS_MODEL_PATH
-    if CURRENT_FS_MODEL_PATH is None or CURRENT_FS_MODEL_PATH != model_path:
+    if FS_MODEL is None or CURRENT_FS_MODEL_PATH is None or CURRENT_FS_MODEL_PATH != model_path:
         CURRENT_FS_MODEL_PATH = model_path
+        FS_MODEL = unload_model(FS_MODEL)
         FS_MODEL = insightface.model_zoo.get_model(model_path, providers=providers)
 
     return FS_MODEL


### PR DESCRIPTION
The models were stuck in global state and would not unload, so added an unload node to allow unloading after reactor is done in the graph.