### PR TITLE
Fix: Skip face-swapping for images without detectable faces (#504)

### DIFF
--- a/scripts/reactor_swapper.py
+++ b/scripts/reactor_swapper.py
@@ -179,7 +179,9 @@ def half_det_size(det_size):
 def analyze_faces(img_data: np.ndarray, det_size=(640, 640)):
     face_analyser = getAnalysisModel(det_size)
     faces = face_analyser.get(img_data)
-
+    if len(faces) == 0:
+        logger.status("No face found so skipping this frame")
+        return faces
     # Try halving det_size if no faces are found
     if len(faces) == 0 and det_size[0] > 320 and det_size[1] > 320:
         det_size_half = half_det_size(det_size)
@@ -188,7 +190,9 @@ def analyze_faces(img_data: np.ndarray, det_size=(640, 640)):
     return faces
 
 def get_face_single(img_data: np.ndarray, face, face_index=0, det_size=(640, 640), gender_source=0, gender_target=0, order="large-small"):
-
+    # if no face found no need to swap
+    if len(face) == 0:
+        return None, 0
     buffalo_path = os.path.join(insightface_models_path, "buffalo_l.zip")
     if os.path.exists(buffalo_path):
         os.remove(buffalo_path)


### PR DESCRIPTION
- Added logic to skip processing for images with no detected faces.
- Ensured face-swapping is applied only to images with valid face detections.

Closes #504